### PR TITLE
Add index files to folders with multiple exports

### DIFF
--- a/source/components/App.js
+++ b/source/components/App.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Router, Route, browserHistory } from 'react-router'
-import ProjectListContainer from './Projects/ProjectListContainer'
+import ProjectListContainer from './Projects'
 
 const App = () => (
   <Router history={ browserHistory }>

--- a/source/components/Projects/index.js
+++ b/source/components/Projects/index.js
@@ -1,0 +1,2 @@
+export { default as ProjectListContainer } from './ProjectListContainer'
+export { default as ProjectListPresentation } from './ProjectListPresentation'

--- a/source/components/TextField/index.js
+++ b/source/components/TextField/index.js
@@ -1,0 +1,3 @@
+export { default as TextFieldContainer } from './TextFieldContainer'
+export { default as TextFieldInputPresentation } from './TextFieldInputPresentation'
+export { default as TextFieldPresentation } from './TextFieldPresentation'

--- a/source/dataServices/database/commands/_tests/couldDo.test.js
+++ b/source/dataServices/database/commands/_tests/couldDo.test.js
@@ -1,6 +1,6 @@
 import { expect } from '../../../../../configuration/testSetup'
 import { newCouldDo, editCouldDo, deleteCouldDo } from '../couldDo'
-import { getCouldDoById } from '../../queries/couldDo'
+import { getCouldDoById } from '../../queries'
 import { mockCouldDoData } from '../../../../testUtilities/mockDatabaseTestData'
 import { withThreeCouldDos } from '../../../../testUtilities/testsHelper'
 

--- a/source/dataServices/database/commands/_tests/project.test.js
+++ b/source/dataServices/database/commands/_tests/project.test.js
@@ -1,6 +1,6 @@
 import { expect } from '../../../../../configuration/testSetup'
 import { newProject, editProject, deleteProject } from '../project'
-import { getProjectById } from '../../queries/project'
+import { getProjectById } from '../../queries'
 import { mockProjectData } from '../../../../testUtilities/mockDatabaseTestData'
 import { withThreeProjects } from '../../../../testUtilities/testsHelper'
 

--- a/source/dataServices/database/commands/index.js
+++ b/source/dataServices/database/commands/index.js
@@ -1,0 +1,3 @@
+export { createRecord, updateRecord, deleteRecord } from './utilities'
+export { newProject, editProject, deleteProject } from './project'
+export { newCouldDo, editCouldDo, deleteCouldDo } from './couldDo'

--- a/source/dataServices/database/queries/index.js
+++ b/source/dataServices/database/queries/index.js
@@ -1,0 +1,3 @@
+export { getRecordById, findAllWhere } from './utilities'
+export { getProjectById, getProjectsByUserId } from './project'
+export { getCouldDoById, getCouldDosByProjectId } from './couldDo'

--- a/source/server/api/v1/routes.js
+++ b/source/server/api/v1/routes.js
@@ -2,15 +2,13 @@ import express from 'express'
 import {
   handleNewCouldDo,
   handleEditCouldDo,
-  handleDeleteCouldDo
-} from '../../controllers/v1/couldDoController'
-import {
+  handleDeleteCouldDo,
   handleGetCouldDosByProjectId,
   handleNewProject,
   handleEditProject,
   handleDeleteProject,
   handleGetProjectsByUserId
- } from '../../controllers/v1/projectController'
+} from '../../controllers/v1'
 
 const router = express()
 

--- a/source/server/controllers/v1/couldDoController.js
+++ b/source/server/controllers/v1/couldDoController.js
@@ -2,7 +2,7 @@ import {
   newCouldDo,
   editCouldDo,
   deleteCouldDo
-} from '../../../dataServices/database/commands/couldDo'
+} from '../../../dataServices/database/commands'
 import { handleResult, handleError } from '../../serverErrorHandler'
 
 const handleNewCouldDo = ( request, response ) =>

--- a/source/server/controllers/v1/index.js
+++ b/source/server/controllers/v1/index.js
@@ -1,0 +1,15 @@
+export {
+  handleNewCouldDo,
+  handleEditCouldDo,
+  handleDeleteCouldDo
+}
+from './couldDoController'
+
+export {
+  handleGetCouldDosByProjectId,
+  handleNewProject,
+  handleEditProject,
+  handleDeleteProject,
+  handleGetProjectsByUserId
+}
+from './projectController'

--- a/source/server/controllers/v1/projectController.js
+++ b/source/server/controllers/v1/projectController.js
@@ -1,12 +1,12 @@
 import {
-  getCouldDosByProjectId
-} from '../../../dataServices/database/queries/couldDo'
+  getCouldDosByProjectId,
+  getProjectsByUserId
+} from '../../../dataServices/database/queries'
 import {
   newProject,
   editProject,
   deleteProject
-} from '../../../dataServices/database/commands/project'
-import { getProjectsByUserId } from '../../../dataServices/database/queries/project'
+} from '../../../dataServices/database/commands'
 import { handleResult, handleError } from '../../serverErrorHandler'
 
 const handleGetCouldDosByProjectId = ( request, response ) =>

--- a/source/testUtilities/testsHelper.js
+++ b/source/testUtilities/testsHelper.js
@@ -1,5 +1,4 @@
-import { newCouldDo } from '../dataServices/database/commands/couldDo'
-import { newProject } from '../dataServices/database/commands/project'
+import { newCouldDo, newProject } from '../dataServices/database/commands'
 import { mockCouldDoData, mockProjectData } from './mockDatabaseTestData'
 
 const withThreeCouldDos = callback => {


### PR DESCRIPTION
Just a little side project I thought of on BART today. Just thought I'd present it as a PR. By utilizing node's use of index.js files we can export multiple modules from multiple directories from the root directory. That way when we import the commands or utilities we don't have to write a separate import for each module that sits in a subfolder. I feel this just kinda cleans up files that are importing multiple modules from the database/commands directory or the database/queries. Since each of those folders contains files with identical names I kept them separated and just added an index for each the utilities and the commands directory.