### PR TITLE
Adds a new port to the testing environment

### DIFF
--- a/configuration/testSetup.js
+++ b/configuration/testSetup.js
@@ -4,6 +4,7 @@ import chaiHttp from 'chai-http'
 import globalState from '../source/components/utilities/globalState'
 
 process.env.NODE_ENV = 'test'
+process.env.PORT = 7357
 const knex = require( '../source/dataServices/database/knex' )
 
 chai.use( chaiHttp )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const determineHost = () => {
     case 'production':
       return "'http://localhost:1337'"
     case 'test':
-      return "'http://localhost:1337'"
+      return "'http://localhost:7357'"
     case 'development':
       return "'http://localhost:1337'"
     default:


### PR DESCRIPTION
There are now a few tests which have the error

``` Warning: [react-router] You cannot change <Router routes>; it will be ignored ```

 is this already expected? 