### PR TITLE
fixes begin script so sass build runs once

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "winston": "^2.3.1"
   },
   "scripts": {
-    "begin": "yarn run migrate && yarn run symlinks && yarn run server & yarn run build & yarn run sass -- -w",
+    "begin": "yarn run sass && yarn run migrate && yarn run symlinks && yarn run server & yarn run build & yarn run sass -- -w",
     "server": "nodemon --exec babel-node source/server/server.js",
     "build": "webpack --colors --progress -w",
     "build:dev": "NODE_ENV=development yarn run build",


### PR DESCRIPTION
The sass build was only happening when a stylesheet is changed.  Now it happens once and then watches for changes.